### PR TITLE
Fix double parenthesis with space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 <!-- There should always be "Unreleased" section at the beginning. -->
 ## Unreleased
+- Fix: Double parenthesis with space around do not compile on Jobs.cz
 
 ## 4.0.0 - 2025-01-09
 - [BC]: Drop support Symfony `4.4` and not LTS versions `6.x`

--- a/src/Compiler/ComponentTagCompiler.php
+++ b/src/Compiler/ComponentTagCompiler.php
@@ -221,7 +221,9 @@ class ComponentTagCompiler
                         |                # or
                         \\\'[^\\\']+\\\' # Capture all that is between \'...\' but not `\'`
                         |                # or
-                        \{[^\{]+\}       # Capture all that is between {...} but not `{`
+                        \{[^\{]+\}       # Capture all that is between {...} but not `}`
+                        |                # or
+                        \{\{[^\}]+\}\}   # Capture all that is between {...} but not `}`
                         |                # or
                         [^>]+            # Capture any character but not `>`
                     )


### PR DESCRIPTION
Try to fix the problem with `<Breadcrumbs items={{ breadcrumb }} />` on Jobs.cz.